### PR TITLE
Publish offline / online MQTT message to status topic

### DIFF
--- a/MQTTLink.cpp
+++ b/MQTTLink.cpp
@@ -83,20 +83,20 @@ void MQTTLinkClass::SubscribeMqtt()    ///called in loop and enabled   example t
 	if (mqEnabled == false) exit;
 	if (mqttclient.connected()) mqttclient.loop();
 
-  if (WiFi.status() == WL_CONNECTED) {
-    if (!mqttclient.connected()) {
-      if (mqttclient.connect(MQTT::Connect("espHeater").set_auth(mqUser, mqPassword)
-                             //.set_keepalive(15)
-                             //Send will message with QoS=0 and retain=true
-                             .set_will(mqPubTopic + "/status", "offline", 0, true)))
-      {
-        mqttclient.publish(MQTT::Publish(mqPubTopic + "/status", "online").set_retain());
+	if (WiFi.status() == WL_CONNECTED) {
+		if (!mqttclient.connected()) {
+			if (mqttclient.connect(MQTT::Connect("espHeater").set_auth(mqUser, mqPassword)
+				//.set_keepalive(15)
+				//Send will message with QoS=0 and retain=true
+				.set_will(mqPubTopic + "/status", "offline", 0, true)))
+			{
+				mqttclient.publish(MQTT::Publish(mqPubTopic + "/status", "online").set_retain());
  
-        mqttclient.subscribe(mqSubTopic + "/#");
-        DebugPrintln("connected to MQTT");
-      } 
-    }
-  }
+				mqttclient.subscribe(mqSubTopic + "/#");
+				DebugPrintln("connected to MQTT");
+			} 
+		}
+ 	}
   
 
 }

--- a/MQTTLink.cpp
+++ b/MQTTLink.cpp
@@ -83,15 +83,21 @@ void MQTTLinkClass::SubscribeMqtt()    ///called in loop and enabled   example t
 	if (mqEnabled == false) exit;
 	if (mqttclient.connected()) mqttclient.loop();
 
-	if (WiFi.status() == WL_CONNECTED) {
-		if (!mqttclient.connected()) {
-			if (mqttclient.connect(MQTT::Connect("espHeater").set_auth(mqUser, mqPassword))) {
-				mqttclient.subscribe(mqSubTopic + "/#");
-				DebugPrintln("connected to MQTT");
-			} 
-		}
-	}
-
+  if (WiFi.status() == WL_CONNECTED) {
+    if (!mqttclient.connected()) {
+      if (mqttclient.connect(MQTT::Connect("espHeater").set_auth(mqUser, mqPassword)
+                             //.set_keepalive(15)
+                             //Send will message with QoS=0 and retain=true
+                             .set_will(mqPubTopic + "/status", "offline", 0, true)))
+      {
+        mqttclient.publish(MQTT::Publish(mqPubTopic + "/status", "online").set_retain());
+ 
+        mqttclient.subscribe(mqSubTopic + "/#");
+        DebugPrintln("connected to MQTT");
+      } 
+    }
+  }
+  
 
 }
 


### PR DESCRIPTION
Changes to set a will message that is published to the status topic to indicate the esp module is offline.  Also, publish a message to the same topic to indicate "online" when MQTT connects successfully.  This is useful for sending notifications (such as push notification via pushbullet) to the user when the esp module goes offline. 